### PR TITLE
Remove build dependency on X11

### DIFF
--- a/README
+++ b/README
@@ -22,14 +22,21 @@ time you log in.
 
 # Building
 
-`configure` will probe the system for dependencies.  On a Fedora 37
-system, I had to install the following packages:
+`configure` will probe the system for dependencies.  On a Fedora
+system, I had to install the following packages for protobuf:
 
 ```
 dnf install protobuf-c-compiler
 dnf install protobuf-c-devel
-dnf install libXScrnSaver-devel
-dnf install glib2-devel
+```
+
+And then either `glib2-devel` for D-Bus (Wayland) or
+`libXScrnSaver-devel` for X11.  If you install both packages, flextime
+will query D-Bus by default.
+
+```
+dnf install glib2-devel # for D-Bus
+dnf install libXScrnSaver-devel # for X11
 ```
 
 Using the follwing commands to find the packages:
@@ -42,7 +49,7 @@ dnf provides "*/gio.h"
 ```
 
 I do not think that there are any runtime dependencies, except for
-X11 and D-Bus (optional.)
+X11 or D-Bus.
 
 # Running the daemon
 

--- a/daemon.c
+++ b/daemon.c
@@ -6,12 +6,16 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <X11/extensions/scrnsaver.h>
 #include <argp.h>
 #include <signal.h>
 #include <syslog.h>
 #include <fcntl.h>
+
+#if defined USE_GIO && USE_GIO == 1
 #include <gio/gio.h>
+#else
+#include <X11/extensions/scrnsaver.h>
+#endif /* USE_GIO */
 
 #include "config.h"
 #include "measurement.pb-c.h"

--- a/print.c
+++ b/print.c
@@ -9,7 +9,6 @@
 #include <sys/types.h>
 #include<sys/dir.h>
 #include <unistd.h>
-#include <X11/extensions/scrnsaver.h>
 #include <argp.h>
 #include <signal.h>
 #include <time.h>


### PR DESCRIPTION
This patch will remove the build and runtime dependency on X11.  In particular, we now require X11 /or/ D-Bus at build time.  The README file has been updated to clarify this fact.

This means that there is no need to install any X11 packages (the libXScrnSaver-devel package) on Fedora 39.  So a standard Fedora 39 Wayland installation only requires the protobuf and glib2 packages at build time.

This close issue #4 